### PR TITLE
minor icsconfig command/attribute changes

### DIFF
--- a/libics/ics.c
+++ b/libics/ics.c
@@ -167,6 +167,41 @@ ics_set_comm_timeout(ics_t ics, unsigned int timeout)
 }
 
 int
+ics_get_hostname(ics_t ics, char **namep)
+{
+    Hostname_Parms p;
+    Hostname_Resp *r;
+
+    assert(ics->ics_magic == ICS_MAGIC);
+    p.action = ICS_READ;
+    r = hostname_1(&p, ics->ics_clnt);
+    if (r == NULL)
+        return ICS_ERROR_CLNT;
+    if (r->error)
+        return r->error;
+    *namep = _mkstr(r->name.name_val, r->name.name_len);
+    return 0;
+}
+
+int
+ics_set_hostname(ics_t ics, char *name)
+{
+    Hostname_Parms p;
+    Hostname_Resp *r;
+
+    assert(ics->ics_magic == ICS_MAGIC);
+    p.action = ICS_WRITE;
+    p.name.name_val = name;
+    p.name.name_len = strlen (name);
+    r = hostname_1(&p, ics->ics_clnt);
+    if (r == NULL)
+        return ICS_ERROR_CLNT;
+    if (r->error)
+        return r->error;
+    return 0;
+}
+
+int
 ics_get_static_ip_mode(ics_t ics, int *flagp)
 {
     Static_IP_Parms p;

--- a/libics/ics.c
+++ b/libics/ics.c
@@ -456,6 +456,20 @@ ics_reload_config(ics_t ics)
 }
 
 int
+ics_reload_factory(ics_t ics)
+{
+    Reload_Factory_Resp *r;
+
+    assert(ics->ics_magic == ICS_MAGIC);
+    r = reload_factory_1(NULL, ics->ics_clnt);
+    if (r == NULL)
+        return ICS_ERROR_CLNT;
+    if (r->error)
+        return r->error;
+    return 0;
+}
+
+int
 ics_commit_config(ics_t ics)
 {
     Commit_Config_Resp *r;

--- a/libics/ics.h
+++ b/libics/ics.h
@@ -86,9 +86,13 @@ int     ics_set_system_controller(ics_t ics, int flag);
 int     ics_get_ren_mode(ics_t ics, int *flagp);
 int     ics_set_ren_mode(ics_t ics, int flag);
 
-/* Force reload of default config.
+/* Reload config from flash.
  */
 int     ics_reload_config(ics_t ics);
+
+/* Reload flash with factory defaults.
+* */
+int     ics_reload_factory(ics_t ics);
 
 /* Commit (write) current config.
  */

--- a/libics/ics.h
+++ b/libics/ics.h
@@ -46,6 +46,11 @@ int     ics_set_interface_name(ics_t ics, char *str);
 int     ics_get_comm_timeout(ics_t ics, unsigned int *timeoutp);
 int     ics_set_comm_timeout(ics_t ics, unsigned int timeout);
 
+/* Get/set hostname.
+ */
+int     ics_get_hostname(ics_t ics, char **namep);
+int     ics_set_hostname(ics_t ics, char *name);
+
 /* Get/set static IP mode.
  */
 int     ics_get_static_ip_mode(ics_t ics, int *flagp);

--- a/libics/ics8000.x
+++ b/libics/ics8000.x
@@ -267,6 +267,16 @@ struct Reload_Config_Resp {
    unsigned int error;
 };
 
+/* The reload_factory procedure is used to cause the Edevice to reset
+ * the default configuration back to factory loaded defaults.  Any/all
+ * modifications to the default configuration are lost as a result.
+ * Note that dynamic in-memory configuration settings are not modified until
+ * a reload_config or reboot is executed.
+ */
+struct Reload_Factory_Resp {
+   unsigned int error;
+};
+
 /* The commit_config procedure is used to cause the current configuration
  * settings to be saved.  Any modified configuration settings now become
  * default settings and will be reloaded as the default settings with either
@@ -325,6 +335,7 @@ program ICSCONFIG {
       Eos_Active_Resp eos_active (Eos_Active_Parms) = 18;
       Eos_Char_Resp eos_char (Eos_Char_Parms) = 19;
       Reload_Config_Resp reload_config (void) = 20;
+      Reload_Factory_Resp reload_factory (void) = 21;
       Commit_Config_Resp commit_config (void) = 22;
       Reboot_Resp reboot (void) = 23;
       Idn_Resp idn_string (void) = 25;

--- a/man/icsconfig.1.in
+++ b/man/icsconfig.1.in
@@ -8,8 +8,9 @@ icsconfig \- configure ICS Electronics VXI-11 based instruments
 .SH DESCRIPTION
 \fBicsconfig\fR is used to configure and access the error log of 
 ICS Electronics VXI-11 based instruments such as the
-8064 Ethernet-Relay Interface and
-8065 Ethernet-GPIB Controller.
+8064 Ethernet-Relay Interface,
+8065 Ethernet-GPIB Controller,
+and 9065 Ethernet-GPIB Controller.
 ICS implemented an open RCPL-based configuration interface
 across all of their VXI-11 based instruments.
 Not all devices implement all functions.

--- a/man/icsconfig.1.in
+++ b/man/icsconfig.1.in
@@ -71,6 +71,9 @@ This value is ignored if \fBenable-dhcp\fR is set to \fIyes\fR.
 The device IPv4 netmask.
 This value is ignored if \fBenable-dhcp\fR is set to \fIyes\fR.
 .TP
+\fBhostname\fR
+The device hostname.
+.TP
 \fBtimeout\fR
 TCP timeout valaue, in seconds.  An inactive TCP channel will be left
 open this length of time before being closed.

--- a/man/icsconfig.1.in
+++ b/man/icsconfig.1.in
@@ -26,8 +26,12 @@ Set the configuration attribute NAME to VALUE.
 Changes do not persist across a reboot unless they are saved with
 the \fBcommit\fR command.
 .TP
-\fBdefault\fR NAME=VALUE
-Load the default configuration.
+\fBreload\fR
+Reload the configuration from flash memory.
+.TP
+\fBfactory\fR
+Reload the flash memory with factory defaults.
+The active configuration is not modified until a \fBreload\fR or reboot.
 .TP
 \fBcommit\fR
 Save the configuration to flash memory.  The configuration is loaded
@@ -35,8 +39,8 @@ from flash upon device reboot.
 .TP
 \fBreboot\fR
 Reboot the device.  All device links will be cleared, all connections closed,
-and all resources released.  Upon reboot, the default configuration settings
-from nonvolatile RAM will be used.
+and all resources released.  Upon reboot, the configuration settings
+from flash will be used.
 .TP
 \fBerrlog\fR
 Display the device's stored error log, one per line.

--- a/src/icsconfig.c
+++ b/src/icsconfig.c
@@ -109,6 +109,7 @@ static const char *attrs[] = {
     "ip-address",
     "ip-gateway",
     "ip-netmask",
+    "hostname",
     "timeout",
     "keepalive",
     "vxi11-interface",
@@ -159,6 +160,12 @@ _print_attribute (ics_t ics, const char *name)
         char *s;
         rc = ics_get_gateway(ics, &s);
         if (rc == 0) {
+            printf("%s\n", s);
+            free(s);
+        }
+    } else if (!strcmp (name, "hostname")) {
+        char *s;
+        if ((rc = ics_get_hostname(ics, &s)) == 0) {
             printf("%s\n", s);
             free(s);
         }
@@ -250,6 +257,8 @@ _set(ics_t ics, int argc, char **argv)
         rc = ics_set_netmask(ics, value);
     } else if (!strcmp (name, "ip-gateway")) {
         rc = ics_set_gateway(ics, value);
+    } else if (!strcmp (name, "hostname")) {
+        rc = ics_set_hostname(ics, value);
     } else if (!strcmp (name, "keepalive")) {
         unsigned int n = strtoul (value, NULL, 10);
         rc = ics_set_keepalive(ics, n);

--- a/src/icsconfig.c
+++ b/src/icsconfig.c
@@ -33,7 +33,8 @@
 static void _list(ics_t ics, int argc, char **argv);
 static void _set(ics_t ics, int argc, char **argv);
 static void _get(ics_t ics, int argc, char **argv);
-static void _default(ics_t ics, int argc, char **argv);
+static void _reload(ics_t ics, int argc, char **argv);
+static void _factory(ics_t ics, int argc, char **argv);
 static void _commit(ics_t ics, int argc, char **argv);
 static void _errlog(ics_t ics, int argc, char **argv);
 static void _reboot(ics_t ics, int argc, char **argv);
@@ -67,8 +68,10 @@ main(int argc, char *argv[])
         _get(ics, argc - optind, argv + optind);
     } else if (!strcmp (cmd, "set")) {
         _set(ics, argc - optind, argv + optind);
-    } else if (!strcmp (cmd, "default")) {
-        _default(ics, argc - optind, argv + optind);
+    } else if (!strcmp (cmd, "reload")) {
+        _reload(ics, argc - optind, argv + optind);
+    } else if (!strcmp (cmd, "factory")) {
+        _factory(ics, argc - optind, argv + optind);
     } else if (!strcmp (cmd, "commit")) {
         _commit(ics, argc - optind, argv + optind);
     } else if (!strcmp (cmd, "errlog")) {
@@ -92,7 +95,8 @@ _usage(void)
   "  list             - display config\n"
   "  get NAME         - display value of config attribute NAME\n"
   "  set NAME=VALUE   - set config attribute NAME to VALUE\n"
-  "  default          - load default config\n"
+  "  reload           - reload config from flash\n"
+  "  factory          - reload flash with factory defaults\n"
   "  commit           - save config to flash for next reboot\n"
   "  errlog           - display device error log\n"
   "  reboot           - reboot device\n");
@@ -273,15 +277,27 @@ _set(ics_t ics, int argc, char **argv)
 }
 
 static void
-_default(ics_t ics, int argc, char **argv)
+_reload(ics_t ics, int argc, char **argv)
 {
     int rc;
     if (argc > 0)
         _usage();
     if ((rc = ics_reload_config(ics)) == 0)
-        printf("default config reloaded\n");
+        printf("config reloaded from flash\n");
     else
-        fprintf(stderr, "default: %s\n", ics_strerror (ics, rc));
+        fprintf(stderr, "reload: %s\n", ics_strerror (ics, rc));
+}
+
+static void
+_factory(ics_t ics, int argc, char **argv)
+{
+    int rc;
+    if (argc > 0)
+        _usage();
+    if ((rc = ics_reload_config(ics)) == 0)
+        printf("flash reloaded with factory defaults\n");
+    else
+        fprintf(stderr, "factory: %s\n", ics_strerror (ics, rc));
 }
 
 static void


### PR DESCRIPTION
Rename `icsconfig default` subcommand to `reload`, and add `factory` subcommand.

Add support for `hostname` config attribute.
